### PR TITLE
Fix regressions

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,8 @@ func main() {
 	sigChan := make(chan os.Signal, 1024)
 	signalMap := make(map[os.Signal][]block)
 
-	for i, elem := range blocks { // initialize blocks
+	// initialize blocks
+	for i := range blocks {
 		go func(bl *block, i int) {
 			bl.pos = i
 
@@ -72,7 +73,7 @@ func main() {
 					bl.run()
 				}
 			}
-		}(&elem, i)
+		}(&blocks[i], i)
 	}
 
 	go func() { // update bar on signal

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 				}
 			}
 
-			finalBytes := finalBytesBuffer.Bytes()[len(delim):]
+			finalBytes := bytes.TrimPrefix(finalBytesBuffer.Bytes(), []byte(delim))
 			xproto.ChangeProperty(x, xproto.PropModeReplace, root, xproto.AtomWmName, xproto.AtomString, 8, uint32(len(finalBytes)), finalBytes) // set the root window name
 			finalBytesBuffer.Reset()
 		}


### PR DESCRIPTION
Sorry! Last patch contained some unspotted errors.

1. Fix regression caused by incorrect usage of immutable loop counter (my bad)
2. Fix regression caused by update to prefix stripping in bar initialisation (introduced in commit e7eef61)

I've preserved simplicity improvements and performance where possible, but removed at least two crashes and one completely broken program. I am still occasionally getting a crash complaining about "concurrent map accesses". When I've got some spare time, I'll bisect it and find out when it started happening - but, like I said, it's occasional, which suggests a race condition.